### PR TITLE
Create Admin-to-Admin Matrix Computation Function

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,23 +1,14 @@
 [BASIC]
 
 # Good variable names which should always be accepted, separated by a comma.
-good-names=i,
-           j,
-           k,
-           f,
-           x,
-           y,
+good-names=a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,
            x1,
            x2,
            y1,
            y2,
-           s,
            p1,
            p2,
            df,
-           a,
-           b,
-           c
 
 [MESSAGES CONTROL]
 

--- a/mobility_pipeline/lib/make_matrix.py
+++ b/mobility_pipeline/lib/make_matrix.py
@@ -1,5 +1,35 @@
 """Functions for making tower-tower, tower-admin, and admin-tower matrices
 
+Matrices:
+* tower-tower: The raw mobility data between cell towers. The value at row ``i``
+    and column ``j`` is the number of people who move on that day from the
+    region served by tower ``i`` to the region served by tower ``j``. Note that
+    really, this is the number of cell phones that connect to tower ``i`` in the
+    morning and tower ``j`` in the evening, which we assume represents a person
+    moving. This matrix has row indices of the origin towers and column indices
+    of the destination towers.
+* tower-admin: Computed from the Voronoi tessellation and the country shapefile,
+    this matrix represents the percent of each admin that is covered by each
+    tower. For any ``x`` in the matrix at row ``i`` and column ``j``, we know
+    that a fraction ``x`` of the admin with index ``i`` is covered by the tower
+    with index ``j``. This means that the matrix has row indices of admin
+    indices and column indices of tower indices.
+* admin-tower: Computed from the Voronoi tessellation and the country shapefile,
+    this matrix represents the percent of each tower's range that is within each
+    admin. For any ``x`` in the matrix at row ``i`` and column ``j``, we know
+    that a fraction ``x`` of the Voronoi cell for the tower with index ``i`` is
+    within the admin
+    with index ``j``. This means that the matrix has row indices of tower
+    indices and column indices of admin indices.
+* admin-admin: This is the final mobility matrix, which represents the number
+    of people who move between admins each day. The value at row ``i`` and
+    column ``j`` is the number of people who move on that day from the admin
+    with index ``i`` to the admin with index ``j``. This is, of course, being
+    estimated from cell phone data and the overlaps as computed in the other
+    matrices.
+
+This strategy is explained by Mike Fabrikant at UNICEF:
+https://medium.com/@mikefabrikant/cell-towers-chiefdoms-and-anonymized-call-detail-records-a-guide-to-creating-a-mobility-matrix-d2d5c1bafb68
 """
 
 import numpy as np  # type: ignore
@@ -33,3 +63,25 @@ def make_tower_tower_matrix(mobility: pd.DataFrame, n_towers: int) \
     mobility = mobility.fillna(0)
     np_array = mobility['COUNT'].values
     return np.reshape(np_array, (n_towers, n_towers))
+
+
+def make_admin_admin_matrix(tower_tower: np.ndarray, tower_admin: np.ndarray,
+                            admin_tower: np.ndarray) -> np.ndarray:
+    """Compute the admin-to-admin matrix
+
+    Computed by multiplying the three provided matrices like so:
+    (tower_admin) * (tower_tower) * (admin_tower)
+
+    Args:
+        tower_tower: The tower-to-tower mobility data
+        tower_admin: Stores the fraction of each admin that is covered by each
+            cell tower
+        admin_tower: Stores the fraction of each cell tower's range that is
+            within each admin
+
+    Returns:
+        An admin-to-admin mobility matrix such that each value with row index
+        ``i`` and column index ``j`` is the estimated number of people who moved
+        that day from the admin with index ``i`` to the admin with index ``j``.
+    """
+    return (tower_admin @ tower_tower) @ admin_tower

--- a/tests/src/test_make_matrix.py
+++ b/tests/src/test_make_matrix.py
@@ -5,7 +5,8 @@ from hypothesis import given
 from hypothesis.strategies import lists, integers
 import numpy as np
 import pandas as pd
-from mobility_pipeline.lib.make_matrix import make_tower_tower_matrix
+from mobility_pipeline.lib.make_matrix import make_tower_tower_matrix, \
+    make_admin_admin_matrix
 
 
 PANDAS_COLUMNS = ['ORIGIN', 'DESTINATION', 'COUNT']
@@ -53,3 +54,17 @@ def test_make_tower_tower_matrix_hypothesis(nums, num):
     expected_mat = np.reshape(np.array(nums), (n_towers, n_towers))
 
     assert np.all(mat == expected_mat)
+
+
+def test_make_matrix_simple():
+    a = np.array([[1, 2],
+                  [3, 4]])
+    b = np.array([[2, 3],
+                  [4, 1]])
+    c = np.array([[0, 1],
+                  [5, 2]])
+    e = np.array([[25, 20],
+                  [65, 48]])
+
+    assert np.all(make_admin_admin_matrix(b, a, c) == (a @ b) @ c)
+    assert np.all((a @ b) @ c == e)


### PR DESCRIPTION
Follows Mike's instructions here: https://medium.com/@mikefabrikant/cell-towers-chiefdoms-and-anonymized-call-detail-records-a-guide-to-creating-a-mobility-matrix-d2d5c1bafb68. Includes documentation and tests. Also updates pylint config file to silence warnings about single-letter variable names, which in the case of matrix multiplication are standard.