### PR TITLE
Upgrade urllib3 to Remediate CVE-2019-11324

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.2
 sphinxcontrib-serializinghtml==1.1.3
 typed-ast==1.3.1
-urllib3==1.25.2
+urllib3==1.24.2
 waitress==1.2.1
 WebOb==1.8.5
 WebTest==2.0.33

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.2
 sphinxcontrib-serializinghtml==1.1.3
 typed-ast==1.3.1
-urllib3==1.24.1
+urllib3==1.25.2
 waitress==1.2.1
 WebOb==1.8.5
 WebTest==2.0.33


### PR DESCRIPTION
CVE Report: https://nvd.nist.gov/vuln/detail/CVE-2019-11324
From GitHub Alerts:
> The urllib3 library before 1.24.2 for Python mishandles certain cases
> where the desired set of CA certificates is different from the OS store
> of CA certificates, which results in SSL connections succeeding in
> situations where a verification failure is the correct outcome. This is
> related to use of the ssl_context, ca_certs, or ca_certs_dir argument.